### PR TITLE
Add mounted folder mode support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,6 +88,8 @@ Options:
   --no-web               Disable web UI (use terminal attach)
   --no-push              Disable automatic branch pushing
   --no-pr                Disable automatic PR creation
+  --mount-folder         Enable mounted folder mode
+  --mount-path <path>    Specify custom mount path
 ```
 
 #### `claude-sandbox attach [container-id]`
@@ -219,6 +221,8 @@ Create a `claude-sandbox.config.json` file (see `claude-sandbox.config.example.j
 - `containerPrefix`: Custom prefix for container names
 - `claudeConfigPath`: Path to Claude configuration file
 - `dockerSocketPath`: Custom Docker/Podman socket path (auto-detected by default)
+- `useMountedFolder`: Enable mounted folder mode (default: false)
+- `mountedFolderPath`: Path to mount into the container (default: current working directory)
 
 #### Mount Configuration
 
@@ -236,6 +240,38 @@ Example use cases:
 - Access host system resources (use with caution)
 
 ## Features
+
+### Mounted Folder Mode
+
+Claude Code Sandbox supports mounting directories directly into containers instead of copying files. This is useful for:
+
+- **Large datasets**: Avoid copying overhead for large files
+- **Non-git directories**: Work with folders that aren't part of a git repository
+- **Real-time changes**: File changes sync instantly without copying delays
+- **Performance**: Direct filesystem access is faster than copying
+
+#### Using Mounted Folder Mode
+
+Via CLI:
+
+```bash
+# Mount current directory
+claude-sandbox start --mount-folder
+
+# Mount a specific directory
+claude-sandbox start --mount-folder --mount-path /path/to/directory
+```
+
+Via configuration file:
+
+```json
+{
+  "useMountedFolder": true,
+  "mountedFolderPath": "/path/to/directory"
+}
+```
+
+**Note**: In mounted folder mode, if the directory isn't a git repository, git operations will be skipped and git monitoring will be disabled. This allows Claude Code to work with any directory, not just git repositories.
 
 ### Podman Support
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -82,6 +82,8 @@ program
     "Start with 'claude' or 'bash' shell",
     /^(claude|bash)$/i,
   )
+  .option("--mount-folder", "Enable mounted folder mode")
+  .option("--mount-path <path>", "Specify custom mount path")
   .action(async (options) => {
     console.log(chalk.blue("🚀 Starting Claude Sandbox..."));
 
@@ -89,6 +91,12 @@ program
     config.includeUntracked = false;
     if (options.shell) {
       config.defaultShell = options.shell.toLowerCase();
+    }
+    if (options.mountFolder) {
+      config.useMountedFolder = true;
+    }
+    if (options.mountPath) {
+      config.mountedFolderPath = options.mountPath;
     }
 
     const sandbox = new ClaudeSandbox(config);
@@ -125,6 +133,8 @@ program
     "Start with 'claude' or 'bash' shell",
     /^(claude|bash)$/i,
   )
+  .option("--mount-folder", "Enable mounted folder mode")
+  .option("--mount-path <path>", "Specify custom mount path")
   .action(async (options) => {
     console.log(chalk.blue("🚀 Starting new Claude Sandbox container..."));
 
@@ -138,6 +148,12 @@ program
     config.prNumber = options.pr;
     if (options.shell) {
       config.defaultShell = options.shell.toLowerCase();
+    }
+    if (options.mountFolder) {
+      config.useMountedFolder = true;
+    }
+    if (options.mountPath) {
+      config.mountedFolderPath = options.mountPath;
     }
 
     const sandbox = new ClaudeSandbox(config);

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -92,7 +92,7 @@ program
     if (options.shell) {
       config.defaultShell = options.shell.toLowerCase();
     }
-    if (options.mountFolder) {
+    if (options.mountFolder || options.mountPath) {
       config.useMountedFolder = true;
     }
     if (options.mountPath) {
@@ -149,7 +149,7 @@ program
     if (options.shell) {
       config.defaultShell = options.shell.toLowerCase();
     }
-    if (options.mountFolder) {
+    if (options.mountFolder || options.mountPath) {
       config.useMountedFolder = true;
     }
     if (options.mountPath) {

--- a/src/container.ts
+++ b/src/container.ts
@@ -25,19 +25,32 @@ export class ContainerManager {
     await container.start();
     console.log(chalk.green("✓ Container started"));
 
-    // Copy working directory into container
-    console.log(chalk.blue("• Copying files into container..."));
-    try {
-      await this._copyWorkingDirectory(container, containerConfig.workDir);
-      console.log(chalk.green("✓ Files copied"));
+    // Copy working directory into container (unless using mounted folder mode)
+    if (!this.config.useMountedFolder) {
+      console.log(chalk.blue("• Copying files into container..."));
+      try {
+        await this._copyWorkingDirectory(container, containerConfig.workDir);
+        console.log(chalk.green("✓ Files copied"));
+      } catch (error) {
+        console.error(chalk.red("✗ File copy failed:"), error);
+        // Clean up container on failure
+        await container.stop().catch(() => {});
+        await container.remove().catch(() => {});
+        this.containers.delete(container.id);
+        throw error;
+      }
+    } else {
+      console.log(chalk.blue("• Using mounted folder mode (skipping file copy)"));
+    }
 
-      // Copy Claude configuration if it exists
+    // Copy Claude configuration if it exists
+    try {
       await this._copyClaudeConfig(container);
 
       // Copy git configuration if it exists
       await this._copyGitConfig(container);
     } catch (error) {
-      console.error(chalk.red("✗ File copy failed:"), error);
+      console.error(chalk.red("✗ Configuration copy failed:"), error);
       // Clean up container on failure
       await container.stop().catch(() => {});
       await container.remove().catch(() => {});
@@ -414,8 +427,16 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
     _workDir: string,
     _credentials: Credentials,
   ): string[] {
-    // NO MOUNTING workspace - we'll copy files instead
     const volumes: string[] = [];
+
+    // Mount workspace directly if in mounted folder mode
+    if (this.config.useMountedFolder) {
+      const mountPath = this.config.mountedFolderPath || process.cwd();
+      console.log(
+        chalk.blue(`✓ Mounting folder: ${mountPath} → /workspace`),
+      );
+      volumes.push(`${mountPath}:/workspace`);
+    }
 
     // NO SSH mounting - we'll use GitHub tokens instead
 

--- a/src/container.ts
+++ b/src/container.ts
@@ -1,5 +1,6 @@
 import Docker from "dockerode";
 import path from "path";
+import fs from "fs";
 import { SandboxConfig, Credentials } from "./types";
 import chalk from "chalk";
 
@@ -431,7 +432,21 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
 
     // Mount workspace directly if in mounted folder mode
     if (this.config.useMountedFolder) {
-      const mountPath = this.config.mountedFolderPath || process.cwd();
+      let mountPath = this.config.mountedFolderPath || process.cwd();
+
+      // Validate and resolve the mount path
+      if (!path.isAbsolute(mountPath)) {
+        // Convert relative path to absolute
+        mountPath = path.resolve(mountPath);
+      }
+
+      // Check if the path exists
+      if (!fs.existsSync(mountPath)) {
+        const errorMsg = `Mounted folder path does not exist: ${mountPath}`;
+        console.error(chalk.red(`✗ Error: ${errorMsg}`));
+        process.exit(1);
+      }
+
       console.log(
         chalk.blue(`✓ Mounting folder: ${mountPath} → /workspace`),
       );

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,12 +39,28 @@ export class ClaudeSandbox {
 
   async run(): Promise<void> {
     try {
-      // Verify we're in a git repository
-      await this.verifyGitRepo();
+      // Verify we're in a git repository (unless using mounted folder mode)
+      let isGitRepo = true;
+      if (!this.config.useMountedFolder) {
+        await this.verifyGitRepo();
+      } else {
+        // Check if it's a git repo, but don't fail if it's not
+        isGitRepo = await this.git.checkIsRepo();
+        if (!isGitRepo) {
+          console.log(
+            chalk.yellow(
+              "⚠ Not a git repository (OK for mounted folder mode)",
+            ),
+          );
+        }
+      }
 
-      // Check current branch
-      const currentBranch = await this.git.branchLocal();
-      console.log(chalk.blue(`Current branch: ${currentBranch.current}`));
+      // Check current branch (only if it's a git repo)
+      let currentBranch = null;
+      if (isGitRepo) {
+        currentBranch = await this.git.branchLocal();
+        console.log(chalk.blue(`Current branch: ${currentBranch.current}`));
+      }
 
       // Determine target branch based on config options (but don't checkout in host repo)
       let branchName = "";
@@ -148,13 +164,17 @@ export class ClaudeSandbox {
         chalk.green(`✓ Started container: ${containerId.substring(0, 12)}`),
       );
 
-      // Start monitoring for commits
-      this.gitMonitor.on("commit", async (commit) => {
-        await this.handleCommit(commit);
-      });
+      // Start monitoring for commits (only if it's a git repo)
+      if (isGitRepo) {
+        this.gitMonitor.on("commit", async (commit) => {
+          await this.handleCommit(commit);
+        });
 
-      await this.gitMonitor.start(branchName);
-      console.log(chalk.blue("✓ Git monitoring started"));
+        await this.gitMonitor.start(branchName);
+        console.log(chalk.blue("✓ Git monitoring started"));
+      } else {
+        console.log(chalk.yellow("⚠ Skipping git monitoring (not a git repo)"));
+      }
 
       // Always launch web UI
       this.webServer = new WebUIServer(this.docker);

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,8 @@ export interface SandboxConfig {
   remoteBranch?: string;
   prNumber?: string;
   dockerSocketPath?: string;
+  useMountedFolder?: boolean;
+  mountedFolderPath?: string;
 }
 
 export interface Credentials {


### PR DESCRIPTION
Implement mounted folder mode to allow direct directory mounting instead of
copying files into containers. This enables better performance for large
datasets, support for non-git directories, and real-time file changes.

Features:
- Added --mount-folder and --mount-path CLI options
- Added useMountedFolder and mountedFolderPath config properties
- Made file copying conditional based on mode
- Skip git operations gracefully for non-git directories
- Added comprehensive documentation

Authored-By: Gregory Bensa <https://github.com/GregoryBensa>
Original commit: https://github.com/GregoryBensa/claude-code-sandbox/commit/13fc6ac54358f72968c6962af33395e4b0985e33

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces mounted folder mode to mount a host directory into /workspace, with new CLI/config options, conditional file copy and git behavior, and updated docs.
> 
> - **Core/Runtime**:
>   - Implement direct workspace mount when `useMountedFolder` is enabled; validates `mountedFolderPath` and binds it to `/workspace`.
>   - Make file copy optional: skip copying repo files when in mounted mode; still copy Claude and git configs.
>   - Git handling is conditional: allow non-git directories; skip branch display and commit monitoring when not a repo.
> - **CLI**:
>   - Add `--mount-folder` and `--mount-path <path>` flags to default and `start` commands; propagate to config.
> - **Config/Types**:
>   - Add `useMountedFolder` and `mountedFolderPath` fields to `SandboxConfig`.
> - **Docs**:
>   - README: document new CLI flags, config options, and a new "Mounted Folder Mode" section with usage examples.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit a283ce2bd70c5f82bc137d03f1d6fe0b8c540355. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->