### PR TITLE
Configure for private deployment

### DIFF
--- a/claude-sandbox.config.json
+++ b/claude-sandbox.config.json
@@ -1,0 +1,28 @@
+{
+  "dockerImage": "claude-code-sandbox:latest",
+  "dockerfile": null,
+  "detached": false,
+  "autoPush": false,
+  "autoCreatePR": false,
+  "autoStartClaude": true,
+  "envFile": ".env",
+  "environment": {
+    "NODE_ENV": "development",
+    "PRIVATE_DEPLOYMENT": "true"
+  },
+  "setupCommands": ["npm install", "npm run build"],
+  "volumes": [],
+  "mounts": [
+    {
+      "source": "./data",
+      "target": "/workspace/data",
+      "readonly": false
+    }
+  ],
+  "allowedTools": ["*"],
+  "maxThinkingTokens": 200000,
+  "bashTimeout": 600000,
+  "containerPrefix": "claude-sandbox-private",
+  "claudeConfigPath": "~/.claude.json",
+  "dockerSocketPath": null
+}


### PR DESCRIPTION
- Disable autoPush and autoCreatePR for private use
- Set PRIVATE_DEPLOYMENT environment variable
- Use custom container prefix for isolation
- Configure mount paths for private environment

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `claude-sandbox.config.json` to configure a private deployment with disabled auto push/PR, env vars, data mount, setup commands, and runtime limits.
> 
> - **Config**:
>   - **New** `claude-sandbox.config.json` for private deployment.
>     - Disables `autoPush` and `autoCreatePR`; enables `autoStartClaude`.
>     - Sets `envFile` to `.env` and `environment` with `NODE_ENV=development`, `PRIVATE_DEPLOYMENT=true`.
>     - Defines `setupCommands` (`npm install`, `npm run build`).
>     - Configures `mounts` for `./data -> /workspace/data` (read-write); `volumes` empty.
>     - Sets `allowedTools` to `*`, `maxThinkingTokens=200000`, `bashTimeout=600000`.
>     - Specifies `dockerImage`, `containerPrefix=claude-sandbox-private`, `claudeConfigPath=~/.claude.json`, `dockerSocketPath=null`, `dockerfile=null`, `detached=false`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 61a9bed80940b8e9188e94d153b234add3aaf0cb. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->