### PR TITLE
Add Linux Docker socket support, OAuth credentials, and --no-web terminal mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,31 @@ claude-sandbox config
 
 ### Configuration
 
+Configuration is loaded from multiple sources (later overrides earlier):
+
+1. **Built-in defaults**
+2. **Global config**: `~/.config/claude-sandbox/config.json`
+3. **Project config**: `./claude-sandbox.config.json`
+
+#### Global Configuration
+
+Set defaults for all projects by creating a global config file:
+
+```bash
+mkdir -p ~/.config/claude-sandbox
+cat > ~/.config/claude-sandbox/config.json << 'EOF'
+{
+  "dockerImage": "my-custom-image:latest",
+  "autoPush": false,
+  "defaultShell": "bash"
+}
+EOF
+```
+
+Project-specific configs can still override these settings.
+
+#### Project Configuration
+
 Create a `claude-sandbox.config.json` file (see `claude-sandbox.config.example.json` for reference):
 
 ```json
@@ -237,15 +262,19 @@ Example use cases:
 
 ## Features
 
-### Podman Support
+### Docker, Colima & Podman Support
 
-Claude Code Sandbox now supports Podman as an alternative to Docker. The tool automatically detects whether you're using Docker or Podman by checking for available socket paths:
+Claude Code Sandbox automatically detects your container runtime by checking for available socket paths:
 
-- **Automatic detection**: The tool checks for Docker and Podman sockets in standard locations
-- **Custom socket paths**: Use the `dockerSocketPath` configuration option to specify a custom socket
-- **Environment variable**: Set `DOCKER_HOST` to override socket detection
+**Detected socket paths (in order):**
 
-Example configuration for Podman:
+- `/var/run/docker.sock` (Docker standard)
+- `$XDG_RUNTIME_DIR/docker.sock` (Docker rootless)
+- `~/.docker/desktop/docker.sock` (Docker Desktop for Linux)
+- `~/.colima/default/docker.sock` (Colima on macOS)
+- `$XDG_RUNTIME_DIR/podman/podman.sock` (Podman rootless)
+
+**Custom socket path:**
 
 ```json
 {
@@ -253,10 +282,7 @@ Example configuration for Podman:
 }
 ```
 
-The tool will automatically detect and use Podman if:
-
-- Docker socket is not available
-- Podman socket is found at standard locations (`/run/podman/podman.sock` or `$XDG_RUNTIME_DIR/podman/podman.sock`)
+Or set the `DOCKER_HOST` environment variable to override detection.
 
 ### Web UI Terminal
 
@@ -286,7 +312,11 @@ Claude Code Sandbox automatically discovers and forwards:
 **Claude Credentials:**
 
 - Anthropic API keys (`ANTHROPIC_API_KEY`)
-- macOS Keychain credentials (Claude Code)
+- OAuth credentials from:
+  - `~/.claude/.credentials.json` (Linux)
+  - `~/.claude/auth.json`
+  - `~/.config/claude/auth.json`
+  - `~/Library/Application Support/Claude/auth.json` (macOS)
 - AWS Bedrock credentials
 - Google Vertex credentials
 - Claude configuration files (`.claude.json`, `.claude/`)

--- a/package-lock.json
+++ b/package-lock.json
@@ -97,6 +97,7 @@
       "integrity": "sha512-bXYxrXFubeYdvB0NhD/NBB3Qi6aZeV20GOWVI47t2dkecCEoneR4NPVcb7abpXDEvejgrUfFtG6vG/zxAKmg+g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.27.1",
@@ -1848,6 +1849,7 @@
       "integrity": "sha512-tbsV1jPne5CkFQCgPBcDOt30ItF7aJoZL997JSF7MhGQqOeT3svWRYxiqlfA5RUdlHN6Fi+EI9bxqbdyAUZjYQ==",
       "dev": true,
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "6.21.0",
         "@typescript-eslint/types": "6.21.0",
@@ -2030,6 +2032,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2532,6 +2535,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001718",
         "electron-to-chromium": "^1.5.160",
@@ -3223,7 +3227,8 @@
       "resolved": "https://registry.npmjs.org/devtools-protocol/-/devtools-protocol-0.0.1452169.tgz",
       "integrity": "sha512-FOFDVMGrAUNp0dDKsAU1TorWJUx2JOU1k9xdgBKKJF3IBh/Uhl2yswG5r3TEAOrCiGY2QRp1e6LVDQrCsTKO4g==",
       "dev": true,
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/diff-sequences": {
       "version": "29.6.3",
@@ -3645,6 +3650,7 @@
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -5056,6 +5062,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -7921,6 +7928,7 @@
       "integrity": "sha512-p1diW6TqL9L07nNxvRMM7hMMw4c5XOo/1ibL4aAIGmSAt9slTE1Xgw5KWuof2uTOvCg9BY7ZRi+GaF+7sfgPeQ==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -8151,7 +8159,8 @@
       "resolved": "https://registry.npmjs.org/xterm/-/xterm-5.3.0.tgz",
       "integrity": "sha512-8QqjlekLUFTrU6x7xck1MsPzPA571K5zNqWm0M0oroYEWVOptZ0+ubQSkQ3uxIEhcIHRujJy6emDWX4A7qyFzg==",
       "deprecated": "This package is now deprecated. Move to @xterm/xterm instead.",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/xterm-addon-fit": {
       "version": "0.8.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -125,6 +125,7 @@ program
     "Start with 'claude' or 'bash' shell",
     /^(claude|bash)$/i,
   )
+  .option("--no-web", "Disable web UI (use terminal attach)")
   .action(async (options) => {
     console.log(chalk.blue("🚀 Starting new Claude Sandbox container..."));
 
@@ -136,6 +137,7 @@ program
     config.targetBranch = options.branch;
     config.remoteBranch = options.remoteBranch;
     config.prNumber = options.pr;
+    config.useWebUI = options.web !== false;
     if (options.shell) {
       config.defaultShell = options.shell.toLowerCase();
     }

--- a/src/config.ts
+++ b/src/config.ts
@@ -11,6 +11,20 @@ const GLOBAL_CONFIG_PATH = path.join(
   "config.json"
 );
 
+// Persistent data locations
+export const SHADOW_BASE_PATH = path.join(
+  os.homedir(),
+  ".cache",
+  "claude-sandbox",
+  "shadows"
+);
+export const SESSION_STORE_PATH = path.join(
+  os.homedir(),
+  ".cache",
+  "claude-sandbox",
+  "sessions.json"
+);
+
 const DEFAULT_CONFIG: SandboxConfig = {
   dockerImage: "claude-code-sandbox:latest",
   autoPush: true,
@@ -21,6 +35,9 @@ const DEFAULT_CONFIG: SandboxConfig = {
   setupCommands: [], // Example: ["npm install", "pip install -r requirements.txt"]
   allowedTools: ["*"], // All tools allowed in sandbox
   includeUntracked: false, // Don't include untracked files by default
+  restartPolicy: "unless-stopped",
+  autoCommit: true,
+  autoCommitIntervalMinutes: 5,
   // maxThinkingTokens: 100000,
   // bashTimeout: 600000, // 10 minutes
 };

--- a/src/container.ts
+++ b/src/container.ts
@@ -851,18 +851,7 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
     try {
       console.log(chalk.blue("• Configuring bypass permissions mode..."));
 
-      // Create or update settings.json to enable bypass permissions mode
-      // This skips the "By proceeding, you accept all responsibility" confirmation prompt
-      const settingsContent = JSON.stringify(
-        {
-          permissions: {
-            defaultMode: "bypassPermissions",
-          },
-        },
-        null,
-        2,
-      );
-
+      // The settings need to have defaultMode at the root level per Claude Code docs
       const setupExec = await container.exec({
         Cmd: [
           "/bin/bash",
@@ -871,26 +860,34 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
           # Ensure .claude directory exists
           mkdir -p /home/claude/.claude &&
 
-          # Check if settings.json exists
-          if [ -f /home/claude/.claude/settings.json ]; then
-            # Merge with existing settings using jq if available, otherwise replace
+          # Update settings.local.json to set bypass permissions mode
+          # Using settings.local.json as it takes precedence for user preferences
+          SETTINGS_FILE="/home/claude/.claude/settings.local.json"
+
+          if [ -f "$SETTINGS_FILE" ]; then
+            # File exists - try to merge with jq, fallback to simple approach
             if command -v jq &> /dev/null; then
-              # Use jq to merge settings, preserving existing values
-              jq '.permissions.defaultMode = "bypassPermissions"' /home/claude/.claude/settings.json > /tmp/settings.json.tmp &&
-              mv /tmp/settings.json.tmp /home/claude/.claude/settings.json
+              jq '. + {"defaultMode": "bypassPermissions"}' "$SETTINGS_FILE" > /tmp/settings.tmp && mv /tmp/settings.tmp "$SETTINGS_FILE"
             else
-              # No jq, just overwrite (existing settings will be lost)
-              echo '${settingsContent}' > /home/claude/.claude/settings.json
+              # No jq - use python if available
+              python3 -c "
+import json
+with open('$SETTINGS_FILE', 'r') as f:
+    data = json.load(f)
+data['defaultMode'] = 'bypassPermissions'
+with open('$SETTINGS_FILE', 'w') as f:
+    json.dump(data, f, indent=2)
+" 2>/dev/null || echo '{"defaultMode": "bypassPermissions"}' > "$SETTINGS_FILE"
             fi
           else
             # Create new settings file
-            echo '${settingsContent}' > /home/claude/.claude/settings.json
+            echo '{"defaultMode": "bypassPermissions"}' > "$SETTINGS_FILE"
           fi &&
 
           # Fix permissions
           chown -R claude:claude /home/claude/.claude &&
           chmod 700 /home/claude/.claude &&
-          chmod 600 /home/claude/.claude/settings.json
+          chmod 600 "$SETTINGS_FILE"
           `,
         ],
         AttachStdout: true,
@@ -899,8 +896,9 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
 
       const stream = await setupExec.start({});
 
-      // Wait for completion
+      // Wait for completion (must consume stream data for it to end)
       await new Promise<void>((resolve, reject) => {
+        stream.on("data", () => {}); // Consume data to allow stream to end
         stream.on("end", resolve);
         stream.on("error", reject);
       });

--- a/src/container.ts
+++ b/src/container.ts
@@ -790,7 +790,20 @@ exec claude --dangerously-skip-permissions' > /start-claude.sh && \\
         const tarFlags = getTarFlags();
         // On macOS, also exclude extended attributes that cause Docker issues
         const additionalFlags = (process.platform as string) === "darwin" ? "--no-xattrs --no-fflags" : "";
-        const combinedFlags = `${tarFlags} ${additionalFlags}`.trim();
+        // Exclude directories that are large, temporary, or actively written to
+        const excludeFlags = [
+          "--exclude=.claude/debug",
+          "--exclude=.claude/cache",
+          "--exclude=.claude/file-history",
+          "--exclude=.claude/session-env",
+          "--exclude=.claude/tasks",
+          "--exclude=.claude/paste-cache",
+          "--exclude=.claude/shell-snapshots",
+          "--exclude=.claude/telemetry",
+          "--exclude=.claude/todos",
+          "--exclude=.claude/statsig",
+        ].join(" ");
+        const combinedFlags = `${tarFlags} ${additionalFlags} ${excludeFlags}`.trim();
         execSync(
           `tar -cf "${tarFile}" ${combinedFlags} -C "${os.homedir()}" .claude`,
           {

--- a/src/docker-config.ts
+++ b/src/docker-config.ts
@@ -1,12 +1,13 @@
 import * as fs from "fs";
 import * as path from "path";
+import * as os from "os";
 
 interface DockerConfig {
   socketPath?: string;
 }
 
 /**
- * Detects whether Docker or Podman is available and returns appropriate configuration
+ * Detects whether Docker, Colima, or Podman is available and returns appropriate configuration
  * @param customSocketPath - Optional custom socket path from configuration
  */
 export function getDockerConfig(customSocketPath?: string): DockerConfig {
@@ -22,8 +23,20 @@ export function getDockerConfig(customSocketPath?: string): DockerConfig {
 
   // Common socket paths to check
   const socketPaths = [
-    // Docker socket paths
+    // Docker standard socket paths
     "/var/run/docker.sock",
+
+    // Docker rootless socket paths (Linux)
+    process.env.XDG_RUNTIME_DIR &&
+      path.join(process.env.XDG_RUNTIME_DIR, "docker.sock"),
+    `/run/user/${process.getuid?.() || 1000}/docker.sock`,
+
+    // Docker Desktop for Linux
+    path.join(os.homedir(), ".docker", "desktop", "docker.sock"),
+
+    // Colima socket paths (macOS)
+    path.join(os.homedir(), ".colima", "default", "docker.sock"),
+    path.join(os.homedir(), ".docker", "run", "docker.sock"),
 
     // Podman rootless socket paths
     process.env.XDG_RUNTIME_DIR &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -212,7 +212,7 @@ export class ClaudeSandbox {
       credentials,
       workDir,
       repoName,
-      dockerImage: this.config.dockerImage || "claude-sandbox:latest",
+      dockerImage: this.config.dockerImage || "claude-code-sandbox:latest",
       prFetchRef,
       remoteFetchRef,
     };

--- a/src/index.ts
+++ b/src/index.ts
@@ -156,25 +156,33 @@ export class ClaudeSandbox {
       await this.gitMonitor.start(branchName);
       console.log(chalk.blue("✓ Git monitoring started"));
 
-      // Always launch web UI
-      this.webServer = new WebUIServer(this.docker);
+      // Launch web UI or attach to terminal directly
+      if (this.config.useWebUI !== false) {
+        this.webServer = new WebUIServer(this.docker);
 
-      // Pass repo info to web server
-      this.webServer.setRepoInfo(process.cwd(), branchName);
+        // Pass repo info to web server
+        this.webServer.setRepoInfo(process.cwd(), branchName);
 
-      const webUrl = await this.webServer.start();
+        const webUrl = await this.webServer.start();
 
-      // Open browser to the web UI with container ID
-      const fullUrl = `${webUrl}?container=${containerId}`;
-      await this.webServer.openInBrowser(fullUrl);
+        // Open browser to the web UI with container ID
+        const fullUrl = `${webUrl}?container=${containerId}`;
+        await this.webServer.openInBrowser(fullUrl);
 
-      console.log(chalk.green(`\n✓ Web UI available at: ${fullUrl}`));
-      console.log(
-        chalk.yellow("Keep this terminal open to maintain the session"),
-      );
+        console.log(chalk.green(`\n✓ Web UI available at: ${fullUrl}`));
+        console.log(
+          chalk.yellow("Keep this terminal open to maintain the session"),
+        );
 
-      // Keep the process running
-      await new Promise(() => {}); // This will keep the process alive
+        // Keep the process running
+        await new Promise(() => {}); // This will keep the process alive
+      } else {
+        // Terminal mode - attach directly to container
+        console.log(chalk.green("\n✓ Attaching to container terminal..."));
+        console.log(chalk.yellow("Press Ctrl+P, Ctrl+Q to detach\n"));
+
+        await this.attachToContainer(containerId);
+      }
     } catch (error) {
       console.error(chalk.red("Error:"), error);
       throw error;
@@ -266,6 +274,77 @@ export class ClaudeSandbox {
     if (this.webServer) {
       await this.webServer.stop();
     }
+  }
+
+  private async attachToContainer(containerId: string): Promise<void> {
+    const container = this.docker.getContainer(containerId);
+
+    // Get current terminal size
+    const getTerminalSize = () => ({
+      h: process.stdout.rows || 24,
+      w: process.stdout.columns || 80,
+    });
+
+    const termSize = getTerminalSize();
+
+    // Execute the startup script in an interactive session
+    const dockerExec = await container.exec({
+      Cmd: ["/bin/bash", "-l", "-c", "/home/claude/start-session.sh"],
+      AttachStdin: true,
+      AttachStdout: true,
+      AttachStderr: true,
+      Tty: true,
+    });
+
+    const stream = await dockerExec.start({
+      hijack: true,
+      stdin: true,
+      Tty: true,
+    });
+
+    // Set initial terminal size
+    await dockerExec.resize(termSize);
+
+    // Handle terminal resize events
+    const resizeHandler = async () => {
+      try {
+        await dockerExec.resize(getTerminalSize());
+      } catch {
+        // Ignore resize errors (exec might have ended)
+      }
+    };
+    process.stdout.on("resize", resizeHandler);
+
+    // Set up raw mode for proper terminal handling
+    if (process.stdin.isTTY) {
+      process.stdin.setRawMode(true);
+    }
+    process.stdin.resume();
+
+    // Pipe streams
+    process.stdin.pipe(stream);
+    stream.pipe(process.stdout);
+
+    // Handle stream end
+    stream.on("end", async () => {
+      process.stdout.off("resize", resizeHandler);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      process.stdin.pause();
+      await this.cleanup();
+      process.exit(0);
+    });
+
+    // Handle Ctrl+C gracefully
+    process.on("SIGINT", async () => {
+      process.stdout.off("resize", resizeHandler);
+      if (process.stdin.isTTY) {
+        process.stdin.setRawMode(false);
+      }
+      await this.cleanup();
+      process.exit(0);
+    });
   }
 }
 

--- a/src/recover.ts
+++ b/src/recover.ts
@@ -1,0 +1,223 @@
+import Docker from "dockerode";
+import chalk from "chalk";
+import inquirer from "inquirer";
+import { exec } from "child_process";
+import { promisify } from "util";
+import * as fsExtra from "fs-extra";
+import path from "path";
+import { SessionStore, SessionRecord } from "./session-store";
+import { WebUIServer } from "./web-server";
+
+const execAsync = promisify(exec);
+
+type RecoverableSession = SessionRecord & {
+  containerState: "running" | "stopped" | "gone";
+  shadowExists: boolean;
+};
+
+export async function recoverSession(
+  docker: Docker,
+  session: RecoverableSession,
+  store: SessionStore,
+): Promise<void> {
+  const shortId = session.sessionId;
+
+  if (session.containerState === "running") {
+    // Container is already running — launch WebUI and re-attach
+    console.log(
+      chalk.green(`Container ${shortId} is running. Launching Web UI...`),
+    );
+
+    const webServer = new WebUIServer(docker);
+    const url = await webServer.start();
+    const fullUrl = `${url}?container=${session.containerId}`;
+    console.log(chalk.green(`Web UI available at: ${fullUrl}`));
+    await webServer.openInBrowser(fullUrl);
+
+    // Update session
+    await store.updateSession(session.containerId, {
+      status: "active",
+      lastActivityTime: new Date().toISOString(),
+    });
+
+    console.log(
+      chalk.yellow("Keep this terminal open to maintain the session"),
+    );
+    // Keep process running
+    await new Promise(() => {});
+  } else if (session.containerState === "stopped") {
+    // Container exists but is stopped — restart and re-attach
+    console.log(chalk.blue(`Restarting container ${shortId}...`));
+
+    const container = docker.getContainer(session.containerId);
+    await container.start();
+
+    console.log(chalk.green(`Container ${shortId} restarted. Launching Web UI...`));
+
+    const webServer = new WebUIServer(docker);
+    const url = await webServer.start();
+    const fullUrl = `${url}?container=${session.containerId}`;
+    console.log(chalk.green(`Web UI available at: ${fullUrl}`));
+    await webServer.openInBrowser(fullUrl);
+
+    // Update session
+    await store.updateSession(session.containerId, {
+      status: "active",
+      lastActivityTime: new Date().toISOString(),
+    });
+
+    console.log(
+      chalk.yellow("Keep this terminal open to maintain the session"),
+    );
+    // Keep process running
+    await new Promise(() => {});
+  } else if (session.shadowExists) {
+    // Container is gone but shadow repo exists
+    console.log(
+      chalk.yellow(
+        `Container ${shortId} is gone, but shadow repo exists at:`,
+      ),
+    );
+    console.log(chalk.white(`  ${session.shadowRepoPath}`));
+
+    const { action } = await inquirer.prompt([
+      {
+        type: "list",
+        name: "action",
+        message: "What would you like to do with the shadow repo?",
+        choices: [
+          {
+            name: "Push to remote (if remote is configured)",
+            value: "push",
+          },
+          {
+            name: "Copy to a local path",
+            value: "copy",
+          },
+          {
+            name: "Show the shadow repo path (and keep it)",
+            value: "show",
+          },
+          {
+            name: "Discard (delete shadow repo and session record)",
+            value: "discard",
+          },
+        ],
+      },
+    ]);
+
+    switch (action) {
+      case "push": {
+        try {
+          // Check if remote is configured
+          const { stdout: remoteOutput } = await execAsync("git remote -v", {
+            cwd: session.shadowRepoPath,
+          });
+
+          if (!remoteOutput.includes("origin")) {
+            console.log(
+              chalk.red("No remote 'origin' configured in shadow repo."),
+            );
+            console.log(
+              chalk.yellow(
+                `Shadow repo path: ${session.shadowRepoPath}`,
+              ),
+            );
+            break;
+          }
+
+          // Stage, commit any remaining changes, and push
+          await execAsync("git add -A", { cwd: session.shadowRepoPath });
+          try {
+            const timestamp = new Date()
+              .toISOString()
+              .replace(/[:.]/g, "-");
+            await execAsync(
+              `git commit -m "[recovery] Recovered changes from ${timestamp}"`,
+              { cwd: session.shadowRepoPath },
+            );
+          } catch {
+            // Nothing to commit — that's fine
+          }
+
+          const { stdout: branchOutput } = await execAsync(
+            "git branch --show-current",
+            { cwd: session.shadowRepoPath },
+          );
+          const branch = branchOutput.trim();
+
+          await execAsync(`git push -u origin ${branch}`, {
+            cwd: session.shadowRepoPath,
+          });
+          console.log(
+            chalk.green(`Pushed branch '${branch}' to remote.`),
+          );
+          await store.removeSession(session.containerId);
+        } catch (error: any) {
+          console.error(chalk.red("Push failed:"), error.message);
+          console.log(
+            chalk.yellow(
+              `Shadow repo preserved at: ${session.shadowRepoPath}`,
+            ),
+          );
+        }
+        break;
+      }
+      case "copy": {
+        const { destPath } = await inquirer.prompt([
+          {
+            type: "input",
+            name: "destPath",
+            message: "Enter destination path:",
+            default: path.join(
+              process.cwd(),
+              `recovered-${session.sessionId}`,
+            ),
+          },
+        ]);
+
+        const resolvedDest = path.resolve(destPath);
+        await fsExtra.copy(session.shadowRepoPath, resolvedDest);
+        console.log(chalk.green(`Copied to: ${resolvedDest}`));
+        await store.removeSession(session.containerId);
+        break;
+      }
+      case "show": {
+        console.log(
+          chalk.blue(`Shadow repo path: ${session.shadowRepoPath}`),
+        );
+        console.log(chalk.gray("Session record preserved."));
+        break;
+      }
+      case "discard": {
+        const { confirmDiscard } = await inquirer.prompt([
+          {
+            type: "confirm",
+            name: "confirmDiscard",
+            message:
+              "Are you sure? This will delete the shadow repo permanently.",
+            default: false,
+          },
+        ]);
+
+        if (confirmDiscard) {
+          await fsExtra.remove(session.shadowRepoPath);
+          await store.removeSession(session.containerId);
+          console.log(chalk.gray("Shadow repo and session record removed."));
+        } else {
+          console.log(chalk.gray("Discard cancelled."));
+        }
+        break;
+      }
+    }
+  } else {
+    // Both container and shadow repo are gone
+    console.log(
+      chalk.red(
+        `Session ${shortId} is unrecoverable (container and shadow repo both gone).`,
+      ),
+    );
+    await store.removeSession(session.containerId);
+    console.log(chalk.gray("Session record cleaned up."));
+  }
+}

--- a/src/session-store.ts
+++ b/src/session-store.ts
@@ -1,0 +1,130 @@
+import fs from "fs/promises";
+import path from "path";
+import * as fsExtra from "fs-extra";
+import Docker from "dockerode";
+import { SESSION_STORE_PATH } from "./config";
+
+export interface SessionRecord {
+  containerId: string;
+  containerName: string;
+  sessionId: string; // first 12 chars of containerId
+  repoPath: string; // host repo path
+  branchName: string; // branch in container
+  originalBranch: string; // host branch at start
+  shadowRepoPath: string;
+  startTime: string; // ISO 8601
+  lastActivityTime: string;
+  status: "active" | "stopped" | "exited";
+  exitType?: "intentional" | "crash" | "unknown";
+  webUIPort?: number;
+  config: {
+    dockerImage?: string;
+    defaultShell?: string;
+    autoCommit?: boolean;
+    autoCommitIntervalMinutes?: number;
+    restartPolicy?: string;
+  };
+}
+
+interface SessionStoreData {
+  sessions: SessionRecord[];
+}
+
+export class SessionStore {
+  private storePath: string;
+
+  constructor(storePath: string = SESSION_STORE_PATH) {
+    this.storePath = storePath;
+  }
+
+  async load(): Promise<SessionRecord[]> {
+    try {
+      const content = await fs.readFile(this.storePath, "utf-8");
+      const data: SessionStoreData = JSON.parse(content);
+      return data.sessions || [];
+    } catch {
+      return [];
+    }
+  }
+
+  private async save(sessions: SessionRecord[]): Promise<void> {
+    const dir = path.dirname(this.storePath);
+    await fsExtra.ensureDir(dir);
+
+    const data: SessionStoreData = { sessions };
+    const tmpPath = this.storePath + ".tmp";
+    await fs.writeFile(tmpPath, JSON.stringify(data, null, 2));
+    await fs.rename(tmpPath, this.storePath);
+  }
+
+  async addSession(session: SessionRecord): Promise<void> {
+    const sessions = await this.load();
+    // Remove any existing session with same containerId
+    const filtered = sessions.filter(
+      (s) => s.containerId !== session.containerId,
+    );
+    filtered.push(session);
+    await this.save(filtered);
+  }
+
+  async updateSession(
+    containerId: string,
+    updates: Partial<SessionRecord>,
+  ): Promise<void> {
+    const sessions = await this.load();
+    const idx = sessions.findIndex((s) => s.containerId === containerId);
+    if (idx >= 0) {
+      sessions[idx] = { ...sessions[idx], ...updates };
+      await this.save(sessions);
+    }
+  }
+
+  async removeSession(containerId: string): Promise<void> {
+    const sessions = await this.load();
+    const filtered = sessions.filter((s) => s.containerId !== containerId);
+    await this.save(filtered);
+  }
+
+  async getRecoverableSessions(
+    docker: Docker,
+  ): Promise<
+    Array<
+      SessionRecord & {
+        containerState: "running" | "stopped" | "gone";
+        shadowExists: boolean;
+      }
+    >
+  > {
+    const sessions = await this.load();
+    const results: Array<
+      SessionRecord & {
+        containerState: "running" | "stopped" | "gone";
+        shadowExists: boolean;
+      }
+    > = [];
+
+    for (const session of sessions) {
+      let containerState: "running" | "stopped" | "gone" = "gone";
+      try {
+        const container = docker.getContainer(session.containerId);
+        const info = await container.inspect();
+        containerState = info.State.Running ? "running" : "stopped";
+      } catch {
+        containerState = "gone";
+      }
+
+      const shadowExists = await fsExtra.pathExists(session.shadowRepoPath);
+
+      // A session is recoverable if the container still exists or the shadow repo is present
+      if (containerState !== "gone" || shadowExists) {
+        results.push({ ...session, containerState, shadowExists });
+      }
+    }
+
+    return results;
+  }
+
+  async clearAll(): Promise<void> {
+    await this.save([]);
+  }
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -27,6 +27,10 @@ export interface SandboxConfig {
   prNumber?: string;
   dockerSocketPath?: string;
   useWebUI?: boolean;
+  restartPolicy?: "no" | "always" | "unless-stopped" | "on-failure";
+  autoCommit?: boolean;
+  autoCommitIntervalMinutes?: number;
+  shadowBasePath?: string;
 }
 
 export interface Credentials {

--- a/src/types.ts
+++ b/src/types.ts
@@ -26,6 +26,7 @@ export interface SandboxConfig {
   remoteBranch?: string;
   prNumber?: string;
   dockerSocketPath?: string;
+  useWebUI?: boolean;
 }
 
 export interface Credentials {

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -866,12 +866,12 @@ export class WebUIServer {
       const container = this.docker.getContainer(containerId);
       const timestamp = new Date().toISOString().replace(/[:.]/g, "-");
 
-      // git add -A stages all changes; git diff --cached --quiet exits 1 when staged changes exist
+      // git add -u stages only tracked files; git diff --cached --quiet exits 1 when staged changes exist
       const commitExec = await container.exec({
         Cmd: [
           "/bin/bash",
           "-c",
-          `cd /workspace && git add -A && git diff --cached --quiet || git commit -m "[auto-save] ${timestamp}"`,
+          `cd /workspace && git add -u && git diff --cached --quiet || git commit -m "[auto-save] ${timestamp}"`,
         ],
         AttachStdout: true,
         AttachStderr: true,

--- a/src/web-server.ts
+++ b/src/web-server.ts
@@ -480,11 +480,12 @@ export class WebUIServer {
           },
           this.shadowBasePath,
         );
-        this.shadowRepos.set(containerId, shadowRepo);
         isNewShadowRepo = true;
 
         // Reset shadow repo to match container's branch (important for PR/remote branch scenarios)
+        // Only add to map after successful initialization to allow retry on failure
         await shadowRepo.resetToContainerBranch(containerId);
+        this.shadowRepos.set(containerId, shadowRepo);
       }
 
       // Sync files from container (inotify already told us there are changes)


### PR DESCRIPTION
## Summary

### Docker Socket Detection
- Add rootless Docker socket paths for Linux (\`$XDG_RUNTIME_DIR/docker.sock\`, \`/run/user/<uid>/docker.sock\`)
- Add Docker Desktop for Linux socket path (\`~/.docker/desktop/docker.sock\`)
- Add Colima socket paths for macOS (\`~/.colima/default/docker.sock\`, \`~/.docker/run/docker.sock\`) - incorporates changes from #35

### OAuth Credential Support
- Fix OAuth credential detection to find \`~/.claude/.credentials.json\` with \`claudeAiOauth\` key
- Exclude actively-written directories (debug, cache, session-env, etc.) when copying \`.claude\` config to prevent tar errors

### Terminal Mode (\`--no-web\`)
- Add \`--no-web\` CLI option for direct terminal attachment without browser
- Implement proper PTY size handling - terminal matches your window size
- Handle terminal resize events so resizing works correctly

### Bug Fixes
- Fix bypass permissions setup stream handling (consume stream data to prevent hanging)
- Use \`settings.local.json\` with correct format for bypass mode configuration

## Test plan

- [x] Tested on Linux with Docker installed via \`apt install docker.io\`
- [x] Verified OAuth credentials are detected and passed to container
- [x] Verified Claude Code starts successfully with Claude Max authentication
- [x] Tested \`--no-web\` terminal mode with proper sizing
- [x] Verified web UI mode still works

Generated with [Claude Code](https://claude.com/claude-code)